### PR TITLE
Regla 6: Eliminación de anillos

### DIFF
--- a/rulebook.md
+++ b/rulebook.md
@@ -89,7 +89,8 @@ El resto de jugadores no pueden interactuar voluntariamente con su cuerpo con el
 Las armas deben de ser seguras. Para todas las armas rigen estas normas:
 
 - Las armas de los *pompfers* tienen que ser de sección redonda y, exceptuando las zonas de agarre, su diámetro debe ser superior a 6 cm e inferior a 15 cm.
-- Las armas rígidas han de tener el alma recta y que no flecte. 
+- Las armas rígidas han de tener el alma recta y que no flecte.
+- Las armas no pueden tener anillos.
 - Las medidas de las armas son máximas estando permitido llevar un arma más corta.
 - Las armas no deben exponer sus materiales y deben estar cubiertas por algún tipo de material.
 - Los pomos de las armas  son considerados zonas de agarre válidas y deben estar **mínimamente acolchados** siendo obligatorio únicamente cubrir la base. 

--- a/rulebook.md
+++ b/rulebook.md
@@ -97,7 +97,7 @@ Las armas deben de ser seguras. Para todas las armas rigen estas normas:
 -  Las armas deben ser lo suficientemente seguras como para no causar daños al impactar.
 
 Se considera un **anillo** a una ampliación en el relieve del acolchado que se situa de la zona de golpeo de un arma.
-No serán considerados anillos los refuerzos necesarios para hacer que la punta sea segura, siempre y cuando estos no generen una diferencia en el radio del arma de más de 2.5 cm ni superen los 15 cm de diametro totales permitidos.
+No serán considerados anillos los refuerzos necesarios para hacer que la punta sea segura, siempre y cuando estos no generen una diferencia en el radio del arma de más de 2.5 cm ni superen los 15 cm de diametro totales permitidos. Tampoco podrán tener una longitud mayor a 10 cm.
 
 Se considera **mínimamente acolchado** cuando, al aplicar una leve presión sobre el material, este cede parcialmente. Asimismo, debe llevar una capa externa de recubrimiento. El acolchado deberá ser fijo y no desplazarse.
 

--- a/rulebook.md
+++ b/rulebook.md
@@ -97,7 +97,7 @@ Las armas deben de ser seguras. Para todas las armas rigen estas normas:
 -  Las armas deben ser lo suficientemente seguras como para no causar daños al impactar.
 
 Se considera un **anillo** a una ampliación en el relieve del acolchado que se situa de la zona de golpeo de un arma.
-No serán considerados anillos los refuerzos necesarios para hacer que la punta sea segura, siempre y cuando estos no generen una diferencia en el radio del arma de más de 2.5 cm ni superen los 15 cm de diametro totales permitidos. Tampoco podrán tener una longitud mayor a 10 cm.
+No serán considerados anillos los refuerzos necesarios para hacer que la punta sea segura, siempre y cuando estos no generen una diferencia en el radio del arma de más de 2 cm ni superen los 15 cm de diametro totales permitidos. Este refuerzo no deberá tener una longitud menor a 5 cm ni mayor a 10 cm.
 
 Se considera **mínimamente acolchado** cuando, al aplicar una leve presión sobre el material, este cede parcialmente. Asimismo, debe llevar una capa externa de recubrimiento. El acolchado deberá ser fijo y no desplazarse.
 

--- a/rulebook.md
+++ b/rulebook.md
@@ -90,7 +90,7 @@ Las armas deben de ser seguras. Para todas las armas rigen estas normas:
 
 - Las armas de los *pompfers* tienen que ser de sección redonda y, exceptuando las zonas de agarre, su diámetro debe ser superior a 6 cm e inferior a 15 cm.
 - Las armas rígidas han de tener el alma recta y que no flecte.
-- Las armas no pueden tener anillos.
+- Las armas no pueden tener anillos a excepción de los refuerzo especiales que generan el escalón del agarre del Q-tip.
 - Las medidas de las armas son máximas estando permitido llevar un arma más corta.
 - Las armas no deben exponer sus materiales y deben estar cubiertas por algún tipo de material.
 - Los pomos de las armas  son considerados zonas de agarre válidas y deben estar **mínimamente acolchados** siendo obligatorio únicamente cubrir la base. 

--- a/rulebook.md
+++ b/rulebook.md
@@ -90,11 +90,14 @@ Las armas deben de ser seguras. Para todas las armas rigen estas normas:
 
 - Las armas de los *pompfers* tienen que ser de sección redonda y, exceptuando las zonas de agarre, su diámetro debe ser superior a 6 cm e inferior a 15 cm.
 - Las armas rígidas han ser rectas y no pueden flectar. 
-- Las armas no pueden tener anillos a excepción de los refuerzo especiales que generan el escalón del agarre del Q-tip.
+- Las armas no pueden tener **anillos** en la zona de golpeo, a excepción de los refuerzo especiales que generan el escalón del agarre del Q-tip.
 - Las medidas de las armas son máximas estando permitido llevar un arma más corta.
 - Las armas no deben exponer sus materiales y deben estar cubiertas por algún tipo de material.
 - Los pomos de las armas  son considerados zonas de agarre válidas y deben estar **mínimamente acolchados** siendo obligatorio únicamente cubrir la base. 
 -  Las armas deben ser lo suficientemente seguras como para no causar daños al impactar.
+
+Se considera un **anillo** a una ampliación en el relieve del acolchado que se situa de la zona de golpeo de un arma.
+No serán considerados anillos los refuerzos necesarios para hacer que la punta sea segura, siempre y cuando estos no generen una diferencia en el radio del arma de más de 2.5 cm ni superen los 15 cm de diametro totales permitidos.
 
 Se considera **mínimamente acolchado** cuando, al aplicar una leve presión sobre el material, este cede parcialmente. Asimismo, debe llevar una capa externa de recubrimiento. El acolchado deberá ser fijo y no desplazarse.
 

--- a/rulebook.md
+++ b/rulebook.md
@@ -90,7 +90,6 @@ Las armas deben de ser seguras. Para todas las armas rigen estas normas:
 
 - Las armas de los *pompfers* tienen que ser de sección redonda y, exceptuando las zonas de agarre, su diámetro debe ser superior a 6 cm e inferior a 15 cm.
 - Las armas rígidas han de tener el alma recta y que no flecte. 
-- Las armas rígidas pueden tener anillos en las zonas de golpeo de hasta 2,5 cm de radio de relieve, sin exceder en ningún caso los 15 cm de diámetro totales. Estos anillos no pueden situarse en la mitad más cercana al agarre de la zona de golpeo, a excepción de los anillos especiales que generan el escalón del agarre del Q-tip.
 - Las medidas de las armas son máximas estando permitido llevar un arma más corta.
 - Las armas no deben exponer sus materiales y deben estar cubiertas por algún tipo de material.
 - Los pomos de las armas  son considerados zonas de agarre válidas y deben estar **mínimamente acolchados** siendo obligatorio únicamente cubrir la base. 
@@ -105,7 +104,7 @@ Las **zonas de golpeo** de las armas deben cumplir lo siguiente:
 - Todos los bordes deben ser redondeados y no deben presentar aristas. 
 - Las zonas de golpeo no deben producir arañazos al resto de jugadores. 
 - Las zonas de golpeo deben medir **al menos 40 cm** de longitud. 
-- Debe existir una diferencia de al menos 4 cm de diámetro en la unión entre las zonas de acolchado y las de agarre de algunas armas. Esta diferencia puede generarse con el propio acolchado o con un anillo de al menos 4 cm de longitud siempre que se mantenga el mínimo de 6 cm de diámetro. Se resaltan en los dibujos de cada arma las zonas en las que tiene que existir dicha diferencia
+- Debe existir una diferencia de al menos 4 cm de diámetro en la unión entre las zonas de acolchado y las de agarre de algunas armas. Esta diferencia puede generarse con el propio acolchado o con un refuerzo de al menos 4 cm de longitud siempre que se mantenga el mínimo de 6 cm de diámetro. Se resaltan en los dibujos de cada arma las zonas en las que tiene que existir dicha diferencia
 
 ![Escalón - Imagen 5](https://fejugger.es/images/doc/reglamento/imagen5.png)
 


### PR DESCRIPTION
Norma en desuso que a veces genera confusión sobre si es un guarda o no, etc.
Se elimian los anilos y se simplifica el reglamento.