### PR TITLE
Regla 7.1: Tantos membrana

### DIFF
--- a/rulebook.md
+++ b/rulebook.md
@@ -190,9 +190,9 @@ Los intervalos o piedras son el medio sonoro continuo que se utilizan en el jugg
 Es el periodo de juego que transcurre desde que el árbitro pregunta al corredor hasta que se logra un tanto, se terminen los intervalos o el árbitro lo indique.
 
 ### 4.1.3 Tantos
-Para anotar un tanto el corredor debe colocar el *jugg* dentro de la base contraria. El tanto será válido si ningún corredor está tocando el *jugg* y este se mantiene dentro de la base. Si el *jugg* se sale o ha sido lanzado o dejado caer dentro de la base, el tanto **NO** será válido. 
+Para anotar un tanto el corredor debe colocar el *jugg* en la base contraria. Si el *jugg* ha sido lanzado o dejado caer dentro de la base, el tanto **NO** será válido. 
 
-Se considerará que el *jugg* está dentro de la base si al menos la mitad del jugg se encuentra dentro.
+Se considerará que el *jugg* está en la base en el momento que el este atraviese la membrana que define el orificio de entrada de la base, independientemente de que porcentaje del *jugg* quede dentro de la base.
 
 En caso de que el tanto **NO** sea válido el punto continuará y un árbitro o un jugador deberán sacar el jugg de la zona de marcaje. 
 


### PR DESCRIPTION
El punto es valido en cuanto el jugg pasa por el agujero de la base, aunque haya otros jugadores en contacto.

Esta norma se vota en contraposición de #10 