### PR TITLE
Regla 8.1: Juego peligroso

### DIFF
--- a/rulebook.md
+++ b/rulebook.md
@@ -430,21 +430,10 @@ Cuando un pineo finaliza puede ocurrir que el jugador arrodillado:
 
 En ambos casos si el intervalo suena justo cuando se está liberando el pineo, no será tenido en cuenta y habrá que esperar a que suene el siguiente.
 
-## 5.7 CARGAS
-Una carga es un golpe que realiza un jugador con alguna parte de su cuerpo o de su arma que no sea considerada zona de impacto sobre un oponente.
+## 5.7 JUEGO PELIGROSO
+Se considerará juego peligroso cualquier acción que ponga en peligro la integridad física de otro jugador, independientemente del equipo al que pertenezca.
 
-Si existe la posibilidad de que las trayectorias de los jugadores hagan que estos choquen en movimiento, deberán detenerse antes del impacto.
-
-Se tendrán en cuenta las siguientes consideraciones:
-
-- Un golpe con el cuerpo contra el cuerpo del rival o una zona de su arma que no produzca impactos válidos, debe considerarse carga, independientemente de la intensidad del mismo.
-- Un golpe entre dos armas, ya sea entre zonas de golpeo válidas o zonas que no produzcan impactos válidos, seguirán siendo golpes entre armas y por lo tanto no serán considerados carga.
-
-El contacto físico entre jugadores del mismo equipo no es considerado carga, por lo que sí está permitido siempre que no ponga en peligro su integridad física.
-
-Siempre que un jugador **RECIBA** una carga y considere que la fuerza del golpe no ha sido significativa, está en la libertad de indicar de manera visible para los árbitros al jugador que realizó la carga que continúe jugando y no lo considere falta. En todo momento es el jugador que recibe la carga el único con potestad para decidir, nunca podrá hacerlo el jugador que la realizó.
-
-Las cargas son consideradas faltas y no producen impactos válidos. Esto es, si se realiza una carga con el fin de obtener cualquier tipo de ventaja a la hora de conseguir un golpe, el impacto no se considerará válido.
+Estas acciones son consideradas faltas y el jugador pasará a ser considerado como *no activo* por lo que no producirá impactos válidos.
 
 ## 5.8 LUCHA DE CORREDORES
 Los corredores pueden luchar entre ellos. Las técnicas que están permitidas son:
@@ -601,7 +590,7 @@ Las situaciones en las que se puede dar un aviso son:
 
 - A un jugador que no realice su cuenta correctamente (no incluye no completarla ni influir negativamente en el desarrollo del juego). 
 - A un jugador que apure mucho la entrada al campo en el inicio del punto. 
-- A un jugador que casi realiza una falta. Ejemplos: tarda un poco en agacharse, casi hace una carga, casi da un tirón con el arma.
+- A un jugador que casi realiza una falta. Ejemplos: tarda un poco en agacharse, casi hace una juego peligroso, casi da un tirón con el arma.
 
 La reiteración de estas acciones podrá acarrear una falta grave al jugador.
 
@@ -666,7 +655,6 @@ Las faltas leves son aquellas acciones que no cambian en exceso el resultado del
 
 Las faltas leves se producen en los siguientes casos:
 
-- Cargas sobre un jugador. 
 - Realizar un pineo ilegal (doble, con el escudo o el kette, uso incorrecto del arma). 
 - Realizar tirones fuertes del arma o la cadena cuando están trabadas entre sí. El sancionado es aquel o aquellos que realizan los tirones. 
 - Golpear el *jugg* con el cuerpo (por ejemplo dar una patada) habiendo o no un arma entre el *jugg* y el cuerpo a excepción de las manos del corredor. 
@@ -731,7 +719,6 @@ Las **faltas graves directas** se producen en los siguientes casos:
 
 - Realizar acciones que pongan en peligro la integridad de otros jugadores.
 	- Juego peligroso. 
-	- Cargas. 
 	- Golpes muy fuertes. 
 	- Golpear a alguien voluntariamente con alguna parte del cuerpo. 
 	- Lanzar el *jugg* contra un jugador o fuera del campo de forma intencionada. 

--- a/rulebook.md
+++ b/rulebook.md
@@ -284,7 +284,7 @@ Se considera golpe a todo contacto que existe entre un arma y un jugador distint
 - Ha de realizarse con la zona de golpeo del arma. 
 - Ha de realizarse con el arma correctamente agarrada. 
 - En el caso del stab no ha de ser un fondo o una estocada. 
-- No ha de realizarse con fuerza desmesurada. 
+- No ha de poner en peligro la integridad física del otro jugador. 
 - El arma no debe estar rota.
 
 Un impacto válido hace que el jugador tenga que arrodillarse y realizar una cuenta de penalización de 5 intervalos (8 en caso de un impacto del *kette*).
@@ -321,9 +321,7 @@ El *kette* no puede girar si tiene un arma enrollada, además de que ningún jug
 ### 5.1.2 Escudo
 El escudo está considerado un arma defensiva con lo que los golpes con el escudo no serán considerados válidos. El escudo debe sujetarse desde el agarre.
 
-### 5.1.3 Fuerza desmesurada y aturdimiento
-Se considerará que un golpe se realiza con **fuerza desmesurada** cuando este se realice con un exceso de fuerza innecesario para la situación del juego. Cualquier jugador podrá solicitar que un golpe recibido fue con fuerza desmesurada. En este caso quedará a discreción del jugador que realizó el impacto agacharse por falta leve. En caso de que decida continuar (por qué considera que el impacto no fue con fuerza desmesurada) un árbitro podrá sancionar con falta grave, si él así lo considera. El ejemplo más claro es cuando se golpea a un corredor, o un cadenero indefenso.
-
+### 5.1.3 Aturdimiento
 Se considerará que un golpe en la cabeza produce **aturdimiento** y deja al jugador inactivo cuando este no pueda seguir jugando. Este podrá realizar la señal de jugador fuera de juego. Si el jugador recibe un impacto en la cabeza y continúa con el transcurso normal del juego (atacando), no se considerará que el golpe aturdió.
 
 ## 5.2 ZONAS DE IMPACTO
@@ -431,7 +429,9 @@ Cuando un pineo finaliza puede ocurrir que el jugador arrodillado:
 En ambos casos si el intervalo suena justo cuando se está liberando el pineo, no será tenido en cuenta y habrá que esperar a que suene el siguiente.
 
 ## 5.7 JUEGO PELIGROSO
-Se considerará juego peligroso cualquier acción que ponga en peligro la integridad física de otro jugador, independientemente del equipo al que pertenezca.
+Se considerará juego peligroso cualquier acción que ponga en peligro de manera directa y suficiente la integridad física de otro jugador, independientemente del equipo al que pertenezca.
+
+Estas acciones tienen que ver más en como se desarrolla la acción que en el tipo de acción en si misma. Es decir, puede producirse *juego peligroso* al chocar contra un jugador, al realizar un impacto, en la lucha de corredores, etc...
 
 Estas acciones son consideradas faltas y el jugador pasará a ser considerado como *no activo* por lo que no producirá impactos válidos.
 
@@ -664,7 +664,6 @@ Las faltas leves se producen en los siguientes casos:
 - Utilizar un arma agarrándola desde una zona diferente a la de agarre con el fin de obtener cualquier tipo de ventaja.
 - Realizar un fondo con el stab.
 - Romper el arma propia.
-- El uso de fuerza desmesurada, tanto en lucha de corredores como a la hora de realizar impactos con un arma.
 - Bloquear el orificio de la zona de marcaje. 
 - Mover el arma a un jugador arrodillado de manera negativa para el dueño y por acción que no sea un lance del juego.
 - Agarrar el arma de otro jugador con las manos u otra parte del cuerpo, excepto si se está destrabando un arma. 
@@ -718,8 +717,10 @@ Si un jugador comete una falta leve durante el juego y no se arrodilla, el árbi
 Las **faltas graves directas** se producen en los siguientes casos:
 
 - Realizar acciones que pongan en peligro la integridad de otros jugadores.
-	- Juego peligroso. 
-	- Golpes muy fuertes. 
+	- Juego peligroso.
+	- Cargas.
+	- Impactos.
+	- Lucha de corredores.
 	- Golpear a alguien voluntariamente con alguna parte del cuerpo. 
 	- Lanzar el *jugg* contra un jugador o fuera del campo de forma intencionada. 
 	- Jugar con un arma rota o peligrosa.


### PR DESCRIPTION
Se eliminan las cargas y la fuerza desmesurada en favor del juego peligroso.

Se vota en contraposición a https://github.com/fejugger/rulebook/pull/12